### PR TITLE
fix: Extended JSONEncoder to deal with datetime

### DIFF
--- a/tap_mssql/client.py
+++ b/tap_mssql/client.py
@@ -2,12 +2,25 @@
 
 This includes mssqlStream and mssqlConnector.
 """
+from __future__ import annotations
+
+import gzip
+import json
+from datetime import datetime
+from uuid import uuid4
 from typing import Any, Dict, Iterable, Optional
+
+import pendulum
 
 import sqlalchemy
 from sqlalchemy.engine import URL
 
 from singer_sdk import SQLConnector, SQLStream
+from singer_sdk.helpers._batch import (
+    BaseBatchFileEncoding,
+    BatchConfig,
+)
+from singer_sdk.streams.core import lazy_chunked_generator
 
 
 class mssqlConnector(SQLConnector):
@@ -76,6 +89,23 @@ class mssqlConnector(SQLConnector):
         return SQLConnector.to_sql_type(jsonschema_type)
 
 
+# Custom class extends json.JSONEncoder
+class CustomJSONEncoder(json.JSONEncoder):
+
+    # Override default() method
+    def default(self, obj):
+
+        # Datetime to string
+        if isinstance(obj, datetime):
+            # Format datetime - `Fri, 21 Aug 2020 17:59:59 GMT`
+            #obj = obj.strftime('%a, %d %b %Y %H:%M:%S GMT')
+            obj = pendulum.instance(obj).isoformat()
+            return obj
+
+        # Default behavior for all other types
+        return super().default(obj)
+
+
 class mssqlStream(SQLStream):
     """Stream class for mssql streams."""
 
@@ -98,3 +128,42 @@ class mssqlStream(SQLStream):
         # retrieval.
         # If no overrides or optimizations are needed, you may delete this method.
         yield from super().get_records(partition)
+
+    def get_batches(
+        self,
+        batch_config: BatchConfig,
+        context: dict | None = None,
+        ) -> Iterable[tuple[BaseBatchFileEncoding, list[str]]]:
+        """Batch generator function.
+
+        Developers are encouraged to override this method to customize batching
+        behavior for databases, bulk APIs, etc.
+
+        Args:
+            batch_config: Batch config for this stream.
+            context: Stream partition or context dictionary.
+
+        Yields:
+            A tuple of (encoding, manifest) for each batch.
+        """
+        sync_id = f"{self.tap_name}--{self.name}-{uuid4()}"
+        prefix = batch_config.storage.prefix or ""
+
+        for i, chunk in enumerate(
+            lazy_chunked_generator(
+                self._sync_records(context, write_messages=False),
+                self.batch_size,
+            ),
+            start=1,
+        ):
+            filename = f"{prefix}{sync_id}-{i}.json.gz"
+            with batch_config.storage.fs() as fs:
+                with fs.open(filename, "wb") as f:
+                    # TODO: Determine compression from config.
+                    with gzip.GzipFile(fileobj=f, mode="wb") as gz:
+                        gz.writelines(
+                            (json.dumps(record, cls=CustomJSONEncoder) + "\n").encode() for record in chunk
+                        )
+                file_url = fs.geturl(filename)
+
+            yield batch_config.encoding, [file_url]


### PR DESCRIPTION
Fixes #2 

I copied `get_batches` from `singer_sdk/streams/core.py` into the `mssqlStream` class. To stop pylance from barking about the new union style not allowed I copied and added `from __future__ import annotations` from `core.py` to the `client.py` file.
I followed this article https://dev.to/kfuquay/extending-pythons-json-encoder-7k0that which has a nice write up on how to extended the JSONEncoder class. The only change needed was to use the pendulum line from the sdk `_typing.py` to format the datetime string
obj = pendulum.instance(obj).isoformat().   
Here is the line with the extended encoder in place
(json.dumps(record, cls=CustomJSONEncoder) + "\n").encode() for record in chunk