### PR TITLE
5-Engine-Parameters-from-Meltano-yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ tap-mssql --about --format=markdown
 | user                | False    | None    | The User Account who has been granted access to the SQL Server |
 | password            | False    | None    | The Password for the User account |
 | database            | False    | None    | The Default database for this connection |
+| sqlalchemy_eng_params| False    | None    | SQLAlchemy Engine Paramaters: fast_executemany, future |
 | sqlalchemy_url_query| False    | None    | SQLAlchemy URL Query options: driver, TrustServerCertificate |
 | batch_config        | False    | None    | Optional Batch Message configuration |
 | start_date          | False    | None    | The earliest record date to sync |

--- a/tap_mssql/client.py
+++ b/tap_mssql/client.py
@@ -69,13 +69,9 @@ class mssqlConnector(SQLConnector):
         eng_prefix = "ep."
         eng_config = {f"{eng_prefix}url":self.sqlalchemy_url,f"{eng_prefix}echo":"False"}
 
-        self.logger.info(super().config.get('sqlalchemy_eng_params'))
-
         if self.config.get('sqlalchemy_eng_params'):
-            for eng_param in super().config['sqlalchemy_eng_params']:
-                eng_config.update(eng_param)
-            
-        self.logger.info(eng_config)
+            for key, value in self.config['sqlalchemy_eng_params'].items():
+                eng_config.update({f"{eng_prefix}{key}": value})
 
         return sqlalchemy.engine_from_config(eng_config, prefix=eng_prefix)
 

--- a/tap_mssql/client.py
+++ b/tap_mssql/client.py
@@ -56,6 +56,17 @@ class mssqlConnector(SQLConnector):
         
         return (config_url)
 
+    def create_sqlalchemy_engine(self) -> sqlalchemy.engine.Engine:
+        """Return a new SQLAlchemy engine using the provided config.
+
+        Developers can generally override just one of the following:
+        `sqlalchemy_engine`, sqlalchemy_url`.
+
+        Returns:
+            A newly created SQLAlchemy engine object.
+        """
+        return sqlalchemy.create_engine(self.sqlalchemy_url, echo=False)
+
     @staticmethod
     def to_jsonschema_type(sql_type: sqlalchemy.types.TypeEngine) -> dict:
         """Returns a JSON Schema equivalent for the given SQL type.

--- a/tap_mssql/client.py
+++ b/tap_mssql/client.py
@@ -3,6 +3,7 @@
 This includes mssqlStream and mssqlConnector.
 """
 from __future__ import annotations
+from copy import deepcopy
 
 import gzip
 import json
@@ -65,7 +66,18 @@ class mssqlConnector(SQLConnector):
         Returns:
             A newly created SQLAlchemy engine object.
         """
-        return sqlalchemy.create_engine(self.sqlalchemy_url, echo=False)
+        eng_prefix = "ep."
+        eng_config = {f"{eng_prefix}url":self.sqlalchemy_url,f"{eng_prefix}echo":"False"}
+
+        self.logger.info(super().config.get('sqlalchemy_eng_params'))
+
+        if self.config.get('sqlalchemy_eng_params'):
+            for eng_param in super().config['sqlalchemy_eng_params']:
+                eng_config.update(eng_param)
+            
+        self.logger.info(eng_config)
+
+        return sqlalchemy.engine_from_config(eng_config, prefix=eng_prefix)
 
     @staticmethod
     def to_jsonschema_type(sql_type: sqlalchemy.types.TypeEngine) -> dict:

--- a/tap_mssql/tap.py
+++ b/tap_mssql/tap.py
@@ -62,7 +62,7 @@ class Tapmssql(SQLTap):
                 description="Run the engine in 2.0 mode: True, False"
                 )
             ),
-            description="SQLAlchemy Engine Paramaters: echo, fast_executemany, future"
+            description="SQLAlchemy Engine Paramaters: fast_executemany, future"
         ),
         th.Property(
             "sqlalchemy_url_query",

--- a/tap_mssql/tap.py
+++ b/tap_mssql/tap.py
@@ -49,6 +49,28 @@ class Tapmssql(SQLTap):
             description="The Default database for this connection"
         ),
         th.Property(
+            "sqlalchemy_eng_params",
+            th.ObjectType(
+                th.Property(
+                "echo",
+                th.StringType,
+                default=False,
+                description="SQLAlchemy echo work to screen: True, False(default)"
+                ),
+                th.Property(
+                "fast_executemany",
+                th.StringType,
+                description="Fast Executemany Mode: True, False"
+                ),
+                th.Property(
+                "future",
+                th.StringType,
+                description="Run the engine in 2.0 mode: True, False"
+                )
+            ),
+            description="SQLAlchemy Engine Paramaters: echo, fast_executemany, future"
+        ),
+        th.Property(
             "sqlalchemy_url_query",
             th.ObjectType(
                 th.Property(

--- a/tap_mssql/tap.py
+++ b/tap_mssql/tap.py
@@ -52,12 +52,6 @@ class Tapmssql(SQLTap):
             "sqlalchemy_eng_params",
             th.ObjectType(
                 th.Property(
-                "echo",
-                th.StringType,
-                default=False,
-                description="SQLAlchemy echo work to screen: True, False(default)"
-                ),
-                th.Property(
                 "fast_executemany",
                 th.StringType,
                 description="Fast Executemany Mode: True, False"


### PR DESCRIPTION
Closes #5 a feature request to allow SQLAlchemy parameters to be set in the meltano.yml.  fast_executemany and future currently supported.  This can be extended upon request