### PR TITLE
fix engine creation not saving port settings

### DIFF
--- a/tap_mssql/client.py
+++ b/tap_mssql/client.py
@@ -50,7 +50,7 @@ class mssqlConnector(SQLConnector):
         )
 
         if 'port' in config:
-            config_url.set(port=config['port'])
+            config_url = config_url.set(port=config['port'])
         
         if 'sqlalchemy_url_query' in config:
             config_url = config_url.update_query_dict(config['sqlalchemy_url_query'])


### PR DESCRIPTION
URL.set returns an immutable copy of the config mapping