### PR TITLE
fix date interval

### DIFF
--- a/tap_mssql/client.py
+++ b/tap_mssql/client.py
@@ -499,7 +499,15 @@ class mssqlStream(SQLStream):
                 start_val = self.get_starting_replication_key_value(context)
 
             if start_val:
-                query = query.where(replication_key_col >= start_val)
+                if replication_key_col.type.python_type == datetime.date:
+                    query = (
+                        query
+                        .where(replication_key_col >= start_val)
+                        .where(replication_key_col < (datetime.datetime.now()+datetime.timedelta(days=1)).strftime('%Y%m%d'))
+                        )
+                else:
+                    query = query.where(replication_key_col >= start_val)
+
 
         if self.ABORT_AT_RECORD_COUNT is not None:
             # Limit record count to one greater than the abort threshold.


### PR DESCRIPTION
Hey @BuzzCutNorman! Thanks for fixing the incremental replication!
I found another bug when trying to download a table with a Date replication field. I have a pretty large view in my database, and if I don't specify an upper bound on the interval, the query tries to read all the data, so I added an upper interval in the future time