### PR TITLE
Require `pymssql` verion 2.2.7

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1333,4 +1333,4 @@ s3 = ["fs-s3fs"]
 [metadata]
 lock-version = "2.0"
 python-versions = "<3.12,>=3.7.1"
-content-hash = "734dca88584e2ab28c6a8decb9db55b957e0508961b84c0a3e1aa494740c3cb3"
+content-hash = "d374b673cc6841d99ef48e60299e5babe143075db49a193f2af0ebf5169fb8e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = "<3.12,>=3.7.1"
 singer-sdk = { version="^0.30.0" }
 fs-s3fs = { version = "^1.1.1", optional = true}
 pyodbc = "^4.0.39"
-pymssql = "^2.2.7"
+pymssql = "2.2.7"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.1"


### PR DESCRIPTION
The tap will fail when trying to install the latest version of pymssql which is 2.2.8.  The tap will install sucessfully when pymssql 2.2.7 is used.