### PR TITLE
Fix: include catalog columns when inspector omits them

### DIFF
--- a/tap_mssql/client.py
+++ b/tap_mssql/client.py
@@ -411,6 +411,40 @@ class MSSQLConnector(SQLConnector):
         """
         return SQLConnector.to_sql_type(jsonschema_type)
 
+    def get_table_columns(
+        self,
+        full_table_name: str | FullyQualifiedName,
+        column_names: list[str] | None = None,
+    ) -> dict[str, sa.Column]:
+        """Return table columns, trusting catalog for columns inspector omits.
+
+        When inspector.get_columns() omits columns (e.g. MSSQL views over
+        table-valued functions in SQLAlchemy 2.x), we still include them if
+        they are in column_names — trust the catalog over live reflection.
+        """
+        result = super().get_table_columns(full_table_name, column_names)
+
+        if not column_names:
+            return result
+
+        inspector_by_key = {
+            col_name.casefold(): (col_name, col)
+            for col_name, col in result.items()
+        }
+
+        columns_dict: dict[str, sa.Column] = {}
+        for col_name in column_names:
+            key = col_name.casefold()
+            if key in inspector_by_key:
+                orig_name, col = inspector_by_key[key]
+                columns_dict[orig_name] = col
+            else:
+                columns_dict[col_name] = sa.Column(
+                    col_name, sa.Text(), nullable=True
+                )
+
+        return columns_dict
+
 
 class JSONLinesBatcher(BaseBatcher):
     """JSON Lines Record Batcher."""

--- a/tests/test_inspector_columns.py
+++ b/tests/test_inspector_columns.py
@@ -1,0 +1,38 @@
+"""Unit tests for inspector column exclusion bug.
+
+When inspector.get_columns() returns fewer columns than the catalog (e.g., for
+MSSQL views over table-valued functions in SQLAlchemy 2.x), those columns are
+silently dropped during sync. This test asserts the desired behavior: catalog
+columns should be included even when the inspector omits them.
+Uses mocks only — no database connection.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import sqlalchemy as sa
+
+from tap_mssql.client import MSSQLConnector
+
+
+def test_get_table_columns_includes_catalog_columns_when_inspector_omits_them() -> None:
+    """When inspector.get_columns() omits a column (e.g. MSSQL views over TVFs in
+    SQLAlchemy 2.x), get_table_columns should still include it if it's in
+    column_names — trust the catalog over live reflection."""
+    mock_engine = MagicMock()
+    mock_inspector = MagicMock()
+    mock_inspector.get_columns.return_value = [
+        {"name": "Id", "type": sa.Integer(), "nullable": False},
+        # Phase intentionally omitted - simulates SQLAlchemy 2.x MSSQL view reflection
+    ]
+
+    config = {"azure_access_tokens": "false"}
+    with (
+        patch.object(MSSQLConnector, "create_engine", return_value=mock_engine),
+        patch("sqlalchemy.inspect", return_value=mock_inspector),
+    ):
+        connector = MSSQLConnector(config=config, sqlalchemy_url="placeholder")
+        result = connector.get_table_columns(
+            "dbo.my_view", column_names=["Id", "Phase"]
+        )
+        assert "Id" in result
+        assert "Phase" in result  # Catalog says Phase exists; it must be included


### PR DESCRIPTION
Fix: include catalog columns when inspector omits them (MSSQL views over TVFs)

When inspector.get_columns() omits columns **even though they exist** (e.g. this happens in SQLAlchemy 2.x when there are views built on top of table-valued functions), because the singer SDK goes back and inspects the table, discarding any column in the catalog that is not returned by the SQLAlchemy inspection.

**get_table_columns** now trusts the catalog and includes columns from column_names even when they're missing from inspector results.

Fixes the issue where certain columns were **silently** dropped during sync even though they were in the catalog.